### PR TITLE
Fix paths for Meteor 0.9.2 and later

### DIFF
--- a/package.js
+++ b/package.js
@@ -1,19 +1,19 @@
 Package.describe({
   name: "natestrauser:x-editable-bootstrap",
   summary: "Latest version of X-Editable for Bootstrap with wysihtml5 rich text editor",
-  version: "1.5.2",
+  version: "1.5.2_1",
   git: "https://github.com/nate-strauser/meteor-x-editable-bootstrap.git"
 });
 
 Package.on_use(function (api){
-  api.versionsFrom("METEOR@0.9.0");
+  api.versionsFrom("0.9.3.1");
   // Package needs jQuery
   api.use('jquery');
 
   // This depends on BS3 JS libraries, including popovers.
   // Need to make sure bootstrap 3 is loaded first, or errors will ensue
   // https://github.com/vitalets/x-editable/issues/395
-  api.use("mizzao:bootstrap-3@3.2.0");
+  api.use("mizzao:bootstrap-3@3.2.0_1");
 
   //x-editable
   api.addFiles('lib/bootstrap-editable/css/bootstrap-editable.css', 'client');

--- a/path-override.css
+++ b/path-override.css
@@ -1,7 +1,7 @@
 .editableform-loading {
-    background-image: url('/packages/natestrauser:x-editable-bootstrap/lib/bootstrap-editable/img/loading.gif');
+    background-image: url('/packages/natestrauser_x-editable-bootstrap/lib/bootstrap-editable/img/loading.gif');
 }
 
 .editable-clear-x {
-   background-image: url('/packages/natestrauser:x-editable-bootstrap/lib/bootstrap-editable/img/clear.png');
+   background-image: url('/packages/natestrauser_x-editable-bootstrap/lib/bootstrap-editable/img/clear.png');
 }


### PR DESCRIPTION
You'll need Meteor 0.9.3 to merge this and publish the package, as it uses the new version syntax for wrapped packages.

This fixes #25.
